### PR TITLE
Infrastructure for cross-matching two binned halo catalogs

### DIFF
--- a/galsampler/__init__.py
+++ b/galsampler/__init__.py
@@ -8,5 +8,4 @@ from ._astropy_init import *
 
 if not _ASTROPY_SETUP_:
     # For egg_info test builds to pass, put package imports here.
-    pass
-    # from .example_mod import *
+    from .host_halo_binning import *

--- a/galsampler/host_halo_binning.py
+++ b/galsampler/host_halo_binning.py
@@ -5,10 +5,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 
 
-__all__ = ('halo_bin_indices', )
+__all__ = ('halo_bin_indices_dict', )
 
 
-def halo_bin_indices(source_halo_arrays, halo_property_bins):
+def halo_bin_indices_dict(source_halo_arrays, halo_property_bins):
     """
     Function used to bin the properties of the source halos.
 
@@ -37,7 +37,7 @@ def halo_bin_indices(source_halo_arrays, halo_property_bins):
     -----
     This function calls `numpy.digitize` separately for each array.
     For cases where the source halo property is larger than the largest bin edge,
-    `numpy.digitize` returns `num_bins`. In such cases, the `halo_bin_indices` function
+    `numpy.digitize` returns `num_bins`. In such cases, the `halo_bin_indices_dict` function
     over-writes these values with `num_bins-1`.
 
     Examples
@@ -51,7 +51,7 @@ def halo_bin_indices(source_halo_arrays, halo_property_bins):
 
     >>> source_halo_arrays = dict(mass=mass, conc=conc)
     >>> halo_property_bins = dict(mass=mass_bins, conc=conc_bins)
-    >>> bin_indices_dict = halo_bin_indices(source_halo_arrays, halo_property_bins)
+    >>> bin_indices_dict = halo_bin_indices_dict(source_halo_arrays, halo_property_bins)
     """
     try:
         halo_properties = set(list(source_halo_arrays.keys()))

--- a/galsampler/host_halo_binning.py
+++ b/galsampler/host_halo_binning.py
@@ -42,6 +42,8 @@ def halo_bin_indices_dict(source_halo_arrays, halo_property_bins):
 
     Examples
     --------
+    In this example, we bin our halos simultaneously by mass and concentration:
+
     >>> num_halos = 50
     >>> mass = 10**np.random.uniform(10, 15, num_halos)
     >>> conc = np.random.uniform(1, 25, num_halos)
@@ -70,3 +72,62 @@ def halo_bin_indices_dict(source_halo_arrays, halo_property_bins):
         bin_indices_dict[key] = bin_indices
 
     return bin_indices_dict
+
+
+def unique_cell_id_from_bin_indices(bin_indices_dict, halo_property_bins):
+    """ Calculate a unique cell ID for the binned halos.
+
+    Parameters
+    ----------
+    bin_indices_dict : dict
+        Python dictionary storing the bin numbers of each halo for each property.
+        This is the output result of the `halo_bin_indices_dict` function.
+        Each key should be the name of a binned halo property;
+        the values will be integer arrays of shape (num_halos, ).
+
+    halo_property_bins : dict
+        Python dictionary storing the collection of bins.
+        Each key should be the name of a binned halo property;
+        each value an ndarray storing the bin edges for that property.
+        The keys must match the keys in ``bin_indices_dict``.
+
+    Returns
+    -------
+    cell_ids : ndarray
+        Numpy integer array of shape (num_halos, ) storing the integer of the
+        (possibly multi-dimensional) bin of each halo.
+
+    Examples
+    --------
+    In this example, we bin our halos simultaneously by mass and concentration:
+
+    >>> num_halos = 50
+    >>> mass = 10**np.random.uniform(10, 15, num_halos)
+    >>> conc = np.random.uniform(1, 25, num_halos)
+    >>> num_bins_mass, num_bins_conc = 12, 11
+    >>> mass_bins = np.logspace(10, 15, num_bins_mass)
+    >>> conc_bins = np.logspace(1.5, 20, num_bins_conc)
+
+    >>> source_halo_arrays = dict(mass=mass, conc=conc)
+    >>> halo_property_bins = dict(mass=mass_bins, conc=conc_bins)
+    >>> bin_indices_dict = halo_bin_indices_dict(source_halo_arrays, halo_property_bins)
+    >>> cell_ids = unique_cell_id_from_bin_indices(bin_indices_dict, halo_property_bins)
+
+    In this case, all values in the ``cell_ids`` array
+    will be in the interval [0, num_bins_mass*num_bins_conc).
+    """
+    try:
+        halo_properties = set(list(bin_indices_dict.keys()))
+        _b = set(list(halo_property_bins.keys()))
+        assert halo_properties == _b
+        assert len(halo_properties) >= 1
+    except:
+        msg = ("Input ``bin_indices_dict`` and ``halo_property_bins`` must be \n"
+            "non-empty python dictionaries with the same keys")
+        raise ValueError(msg)
+
+    num_bins_dict = {key: len(halo_property_bins[key]) for key in halo_properties}
+
+    return np.ravel_multi_index(list(bin_indices_dict.values()),
+            list(num_bins_dict.values()))
+

--- a/galsampler/host_halo_binning.py
+++ b/galsampler/host_halo_binning.py
@@ -5,7 +5,52 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 
 
-__all__ = ('halo_bin_indices_dict', )
+__all__ = ('halo_bin_indices', )
+
+
+def halo_bin_indices(source_halo_arrays, halo_property_bins):
+    """ Calculate a unique cell ID for every halo.
+
+    Parameters
+    ----------
+    source_halo_arrays : dict
+        Python dictionary storing the collection of properties of the source halos.
+        Each key should be the name of the property to be binned;
+        each value an ndarray of shape (num_halos, ).
+        The keys must match the keys in ``halo_property_bins``.
+
+    halo_property_bins : dict
+        Python dictionary storing the collection of bins.
+        Each key should be the name of the property to be binned;
+        each value an ndarray storing the bin edges for that property.
+        The keys must match the keys in ``source_halo_arrays``.
+
+    Returns
+    -------
+    cell_ids : ndarray
+        Numpy integer array of shape (num_halos, ) storing the integer of the
+        (possibly multi-dimensional) bin of each halo.
+
+    Examples
+    --------
+    In this example, we bin our halos simultaneously by mass and concentration:
+
+    >>> num_halos = 50
+    >>> mass = 10**np.random.uniform(10, 15, num_halos)
+    >>> conc = np.random.uniform(1, 25, num_halos)
+    >>> num_bins_mass, num_bins_conc = 12, 11
+    >>> mass_bins = np.logspace(10, 15, num_bins_mass)
+    >>> conc_bins = np.logspace(1.5, 20, num_bins_conc)
+
+    >>> source_halo_arrays = dict(mass=mass, conc=conc)
+    >>> halo_property_bins = dict(mass=mass_bins, conc=conc_bins)
+    >>> cell_ids = halo_bin_indices(source_halo_arrays, halo_property_bins)
+
+    In this case, all values in the ``cell_ids`` array
+    will be in the interval [0, num_bins_mass*num_bins_conc).
+    """
+    bin_indices_dict = halo_bin_indices_dict(source_halo_arrays, halo_property_bins)
+    return unique_cell_id_from_bin_indices(bin_indices_dict, halo_property_bins)
 
 
 def halo_bin_indices_dict(source_halo_arrays, halo_property_bins):

--- a/galsampler/host_halo_selection.py
+++ b/galsampler/host_halo_selection.py
@@ -3,7 +3,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
+from astropy.table import Table
+from halotools.utils import crossmatch
+
 from .cython_kernels import source_halo_index_selection_kernel
+from .host_halo_binning import halo_bin_indices
 
 
 def source_halo_index_selection(first, last, num_select):
@@ -41,3 +45,41 @@ def source_halo_index_selection(first, last, num_select):
     assert len(first) == len(last) == len(num_select), "Input 1d arrays must be the same length"
     assert np.all(last - first > 0), "Must have at least one source halo per target"
     return np.array(source_halo_index_selection_kernel(first, last, num_select))
+
+
+def compute_richness(host_halo_ids):
+    """
+    """
+    nhalos = host_halo_ids.shape[0]
+    host_halo_ngals = np.zeros(nhalos).astype('i4')
+
+    uval, idx_uval, counts = np.unique(host_halo_ids, return_index=True, return_counts=True)
+    host_halo_ngals[idx_uval] = counts
+
+    idxA, idxB = crossmatch(host_halo_ids, host_halo_ids[idx_uval])
+    host_halo_ngals[idxA] = host_halo_ngals[idx_uval][idxB]
+
+    return host_halo_ngals
+
+
+def format_source_catalog(source_halos, halo_property_bins):
+    """
+    Examples
+    --------
+    >>> from galsampler.tests import fake_source_galaxy_catalog
+    >>> source_halos = fake_source_galaxy_catalog()
+    >>> num_bins_mass, num_bins_conc = 12, 11
+    >>> mass_bins = np.logspace(10, 15, num_bins_mass)
+    >>> conc_bins = np.logspace(1.5, 20, num_bins_conc)
+    >>> halo_property_bins = dict(host_halo_mass=mass_bins, host_halo_conc=conc_bins)
+    >>> formatted_source_halos = format_source_catalog(source_halos, halo_property_bins)
+    """
+    source_halos = Table(source_halos)
+    source_halos['host_halo_ngals'] = compute_richness(source_halos['host_halo_id'])
+
+    source_halos['halo_bin_number'] = halo_bin_indices(
+        {key: source_halos[key] for key in halo_property_bins.keys()}, halo_property_bins)
+
+    source_halos.sort(('halo_bin_number', 'host_halo_id', 'satellite'))
+
+    return source_halos

--- a/galsampler/host_halo_selection.py
+++ b/galsampler/host_halo_selection.py
@@ -3,11 +3,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
-from astropy.table import Table
-from halotools.utils import crossmatch
 
 from .cython_kernels import source_halo_index_selection_kernel
-from .host_halo_binning import halo_bin_indices
 
 
 def source_halo_index_selection(first, last, num_select):
@@ -47,39 +44,3 @@ def source_halo_index_selection(first, last, num_select):
     return np.array(source_halo_index_selection_kernel(first, last, num_select))
 
 
-def compute_richness(host_halo_ids):
-    """
-    """
-    nhalos = host_halo_ids.shape[0]
-    host_halo_ngals = np.zeros(nhalos).astype('i4')
-
-    uval, idx_uval, counts = np.unique(host_halo_ids, return_index=True, return_counts=True)
-    host_halo_ngals[idx_uval] = counts
-
-    idxA, idxB = crossmatch(host_halo_ids, host_halo_ids[idx_uval])
-    host_halo_ngals[idxA] = host_halo_ngals[idx_uval][idxB]
-
-    return host_halo_ngals
-
-
-def format_source_catalog(source_halos, halo_property_bins):
-    """
-    Examples
-    --------
-    >>> from galsampler.tests import fake_source_galaxy_catalog
-    >>> source_halos = fake_source_galaxy_catalog()
-    >>> num_bins_mass, num_bins_conc = 12, 11
-    >>> mass_bins = np.logspace(10, 15, num_bins_mass)
-    >>> conc_bins = np.logspace(1.5, 20, num_bins_conc)
-    >>> halo_property_bins = dict(host_halo_mass=mass_bins, host_halo_conc=conc_bins)
-    >>> formatted_source_halos = format_source_catalog(source_halos, halo_property_bins)
-    """
-    source_halos = Table(source_halos)
-    source_halos['host_halo_ngals'] = compute_richness(source_halos['host_halo_id'])
-
-    source_halos['halo_bin_number'] = halo_bin_indices(
-        {key: source_halos[key] for key in halo_property_bins.keys()}, halo_property_bins)
-
-    source_halos.sort(('halo_bin_number', 'host_halo_id', 'satellite'))
-
-    return source_halos

--- a/galsampler/numpy_random_context.py
+++ b/galsampler/numpy_random_context.py
@@ -1,0 +1,30 @@
+"""
+"""
+
+__all__ = ('NumpyRNGContext', )
+
+
+class NumpyRNGContext(object):
+    """ Context manager enabling deterministic results from
+    functions in np.random.
+
+    The `NumpyRNGContext` context manager preserves
+    the entry value of the input number seed upon exit.
+
+    Notes
+    -----
+    This code has been lifted wholesale from `astropy.utils.misc`
+    """
+    def __init__(self, seed):
+        self.seed = seed
+
+    def __enter__(self):
+        from numpy import random
+
+        self.startstate = random.get_state()
+        random.seed(self.seed)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        from numpy import random
+
+        random.set_state(self.startstate)

--- a/galsampler/populate_halos.py
+++ b/galsampler/populate_halos.py
@@ -12,7 +12,8 @@ from .host_halo_binning import halo_bin_indices
 __all__ = ('populate_target_halos', )
 
 
-def populate_target_halos(source_galaxies, target_halos, halo_property_bins):
+def populate_target_halos(source_galaxies, target_halos, halo_property_bins,
+        source_target_key_correspondence={}):
     """
     Parameters
     ----------
@@ -30,8 +31,21 @@ def populate_target_halos(source_galaxies, target_halos, halo_property_bins):
         the halo populations in the source and target catalogs.
         Each key should be the name of the property to be binned;
         each value an ndarray storing the bin edges for that property.
-        Each key of ``halo_property_bins`` must appear in both
-        ``source_galaxies`` and ``target_halos``.
+        Each key of ``halo_property_bins`` must appear as a column name in
+        ``source_galaxies``. Additionally, for any key that does not appear
+        as a column name in ``target_halos``, there must be an entry in
+        the ``source_target_key_correspondence`` dictionary.
+
+    source_target_key_correspondence : dict, optional
+        Python dictionary providing correspondence between
+        source/target column names used to bin the halo properties.
+        There must be a key for every key of ``halo_property_bins``
+        that does not appear as a column name in ``target_halos``.
+        The value bound to each such key should be the corresponding colum name
+        in the ``target_halos`` catalog.
+
+        Default is an empty dictionary, in which case it will be assumed that
+        all column names correspond with one another.
 
     Returns
     -------
@@ -40,12 +54,32 @@ def populate_target_halos(source_galaxies, target_halos, halo_property_bins):
         the output galaxy catalog
 
     """
-    source_galaxies = format_source_catalog(source_galaxies)
+    _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+        source_target_key_correspondence)
+
+    source_galaxies = format_source_catalog(source_galaxies, halo_property_bins)
+    target_halos = format_source_catalog(target_halos, halo_property_bins,
+            source_target_key_correspondence)
     raise NotImplementedError
 
 
 def compute_richness(host_halo_ids):
-    """
+    """ Calculate the multiplicity of each entry of ``host_halo_ids``.
+
+    Parameters
+    ----------
+    host_halo_ids : ndarray
+        Numpy array of (possibly repeated) integers of shape (npts, )
+
+    Returns
+    -------
+    richness : ndarray
+        Numpy array of integers of shape (npts, ) storing the multiplicity of each entry
+
+    Examples
+    --------
+    >>> host_halo_ids = np.random.randint(0, 100, 1000)
+    >>> richness = compute_richness(host_halo_ids)
     """
     nhalos = host_halo_ids.shape[0]
     host_halo_ngals = np.zeros(nhalos).astype('i4')
@@ -60,7 +94,8 @@ def compute_richness(host_halo_ids):
 
 
 def format_source_catalog(source_galaxies, halo_property_bins):
-    """
+    """ Transform the source galaxy catalog into the required format.
+
     Examples
     --------
     >>> from galsampler.tests import fake_source_galaxy_catalog
@@ -82,10 +117,90 @@ def format_source_catalog(source_galaxies, halo_property_bins):
     return source_galaxies
 
 
-def format_target_catalog(target_halos, halo_property_bins):
+def _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+        source_target_key_correspondence):
     """
+    """
+    source_names = list(source_galaxies.keys())
+    target_names = list(target_halos.keys())
+    binning_names = list(halo_property_bins.keys())
+    correspondence_names = list(source_target_key_correspondence.keys())
+
+    missing_source_name_msg = ("Column name ``{0}`` appears in ``halo_property_bins`` "
+        "but not in ``source_galaxies``")
+    missing_key_correspondence_name_msg = ("Column name ``{0}`` appears in ``halo_property_bins`` "
+        "but not in ``target_halos`` nor ``source_target_key_correspondence``")
+
+    missing_target_name_msg = ("Column name ``{0}`` appears in ``halo_property_bins`` "
+        "but not in ``source_galaxies``.\n"
+        "According to ``source_target_key_correspondence``, there should be a "
+        "``{1}`` key in target_halos\nbut this key does not exist in target_halos")
+
+    for binning_name in binning_names:
+
+        try:
+            assert binning_name in source_names
+        except:
+            raise KeyError(missing_source_name_msg.format(binning_name))
+
+        try:
+            assert binning_name in target_names
+        except:
+            try:
+                assert binning_name in correspondence_names
+            except:
+                raise KeyError(missing_key_correspondence_name_msg.format(binning_name))
+
+            try:
+                target_name = source_target_key_correspondence[binning_name]
+                assert target_name in target_names
+            except:
+                raise KeyError(missing_target_name_msg.format(binning_name, target_name))
+
+
+def format_target_catalog(target_halos, halo_property_bins,
+        source_target_key_correspondence={}):
+    """ Transform the target halo catalog into the required format.
+
+    Parameters
+    ----------
+    target_halos : ndarray
+        Numpy structured array or Astropy Table of shape (num_target_halos, )
+        storing the halo catalog that will become populated
+        with a Monte Carlo resampling of the source galaxies.
+
+    halo_property_bins : dict
+        Python dictionary storing the collection of bins used to match
+        the halo populations in the source and target catalogs.
+        Each key should be the name of the property to be binned;
+        each value an ndarray storing the bin edges for that property.
+        For any key of ``halo_property_bins`` that does not appear
+        as a column name in ``target_halos``, there must be an entry in
+        the ``source_target_key_correspondence`` dictionary.
+        The value bound to each such key should be the corresponding colum name
+        in the ``target_halos`` catalog.
+
+        See Examples for an explicit demonstration.
+
+    source_target_key_correspondence : dict, optional
+        Python dictionary providing correspondence between
+        source/target column names used to bin the halo properties.
+        For every key of ``halo_property_bins``
+        that does not appear as a column name in ``target_halos``,
+        there must be a key in ``source_target_key_correspondence``.
+        The value bound to each such key should be the corresponding colum name
+        in the ``target_halos`` catalog.
+
+        Default is an empty dictionary, in which case it will be assumed that
+        all column names correspond with one another.
+
+        See Examples for an explicit demonstration.
+
     Examples
     --------
+    First we show the case where ``target_halos`` and ``halo_property_bins``
+    have the same keys:
+
     >>> from galsampler.tests import fake_target_halo_catalog
     >>> target_halos = fake_target_halo_catalog()
     >>> num_bins_mass, num_bins_conc = 12, 11
@@ -93,11 +208,34 @@ def format_target_catalog(target_halos, halo_property_bins):
     >>> conc_bins = np.logspace(1.5, 20, num_bins_conc)
     >>> halo_property_bins = dict(mass=mass_bins, conc=conc_bins)
     >>> formatted_target_halos = format_target_catalog(target_halos, halo_property_bins)
+
+    Now we show the case requiring the ``source_target_key_correspondence`` feature:
+
+    >>> halo_property_bins = dict(mass=mass_bins, other_conc_name=conc_bins)
+    >>> source_target_key_correspondence = dict(other_conc_name='conc')
+    >>> formatted_target_halos = format_target_catalog(target_halos, halo_property_bins, source_target_key_correspondence=source_target_key_correspondence)
+
     """
+    missing_colname_msg = ("Column name ``{0}`` appears in ``halo_property_bins`` "
+        "but not in ``target_halos``.\n"
+        "According to ``source_target_key_correspondence``, there should be a "
+        "``{1}`` key in ``target_halos``\nbut this key does not exist in ``target_halos``")
+
     target_halos = Table(target_halos)
 
-    target_halos['halo_bin_number'] = halo_bin_indices(
-        {key: target_halos[key] for key in halo_property_bins.keys()}, halo_property_bins)
+    source_halo_arrays = {}
+    for binning_key in halo_property_bins.keys():
+        try:
+            source_halo_arrays[binning_key] = target_halos[binning_key]
+        except KeyError:
+            try:
+                matching_key = source_target_key_correspondence[binning_key]
+                source_halo_arrays[binning_key] = target_halos[matching_key]
+            except KeyError:
+                raise KeyError(missing_colname_msg.format(binning_key, matching_key))
+                source_halo_arrays[binning_key] = target_halos
+
+    target_halos['halo_bin_number'] = halo_bin_indices(source_halo_arrays, halo_property_bins)
 
     target_halos.sort('halo_bin_number')
 

--- a/galsampler/populate_halos.py
+++ b/galsampler/populate_halos.py
@@ -3,6 +3,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
+from astropy.table import Table
+from halotools.utils import crossmatch
+
+from .host_halo_binning import halo_bin_indices
 
 
 __all__ = ('populate_target_halos', )
@@ -37,3 +41,41 @@ def populate_target_halos(source_galaxies, target_halos, halo_property_bins):
 
     """
     raise NotImplementedError
+
+
+def compute_richness(host_halo_ids):
+    """
+    """
+    nhalos = host_halo_ids.shape[0]
+    host_halo_ngals = np.zeros(nhalos).astype('i4')
+
+    uval, idx_uval, counts = np.unique(host_halo_ids, return_index=True, return_counts=True)
+    host_halo_ngals[idx_uval] = counts
+
+    idxA, idxB = crossmatch(host_halo_ids, host_halo_ids[idx_uval])
+    host_halo_ngals[idxA] = host_halo_ngals[idx_uval][idxB]
+
+    return host_halo_ngals
+
+
+def format_source_catalog(source_halos, halo_property_bins):
+    """
+    Examples
+    --------
+    >>> from galsampler.tests import fake_source_galaxy_catalog
+    >>> source_halos = fake_source_galaxy_catalog()
+    >>> num_bins_mass, num_bins_conc = 12, 11
+    >>> mass_bins = np.logspace(10, 15, num_bins_mass)
+    >>> conc_bins = np.logspace(1.5, 20, num_bins_conc)
+    >>> halo_property_bins = dict(host_halo_mass=mass_bins, host_halo_conc=conc_bins)
+    >>> formatted_source_halos = format_source_catalog(source_halos, halo_property_bins)
+    """
+    source_halos = Table(source_halos)
+    source_halos['host_halo_ngals'] = compute_richness(source_halos['host_halo_id'])
+
+    source_halos['halo_bin_number'] = halo_bin_indices(
+        {key: source_halos[key] for key in halo_property_bins.keys()}, halo_property_bins)
+
+    source_halos.sort(('halo_bin_number', 'host_halo_id', 'satellite'))
+
+    return source_halos

--- a/galsampler/populate_halos.py
+++ b/galsampler/populate_halos.py
@@ -1,0 +1,39 @@
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+
+
+__all__ = ('populate_target_halos', )
+
+
+def populate_target_halos(source_galaxies, target_halos, halo_property_bins):
+    """
+    Parameters
+    ----------
+    source_galaxies : ndarray
+        Numpy structured array of shape (num_source_gals, ) storing
+        the galaxy catalog that will be scaled up to the target simulation.
+
+    target_halos : ndarray
+        Numpy structured array of shape (num_target_halos, ) storing
+        the halo catalog that will become populated with a Monte Carlo
+        resampling of the source halos.
+
+    halo_property_bins : dict
+        Python dictionary storing the collection of bins used to match
+        the halo populations in the source and target catalogs.
+        Each key should be the name of the property to be binned;
+        each value an ndarray storing the bin edges for that property.
+        Each key of ``halo_property_bins`` must appear in both
+        ``source_galaxies`` and ``target_halos``.
+
+    Returns
+    -------
+    target_galaxies : ndarray
+        Numpy structured array of shape (num_target_gals, ) storing
+        the output galaxy catalog
+
+    """
+    raise NotImplementedError

--- a/galsampler/tests/__init__.py
+++ b/galsampler/tests/__init__.py
@@ -2,3 +2,4 @@
 """
 This module contains package tests.
 """
+from .fake_catalogs import fake_source_galaxy_catalog

--- a/galsampler/tests/__init__.py
+++ b/galsampler/tests/__init__.py
@@ -2,4 +2,4 @@
 """
 This module contains package tests.
 """
-from .fake_catalogs import fake_source_galaxy_catalog
+from .fake_catalogs import *

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -12,10 +12,10 @@ __all__ = ('fake_source_galaxy_catalog', )
 
 
 source_gals_type_list = list((('gal_id', 'i8'),
-    ('mass', 'f4'), ('conc', 'f4'), ('host_rvir', 'f4'),
+    ('host_halo_mass', 'f4'), ('host_halo_conc', 'f4'), ('host_halo_rvir', 'f4'),
     ('satellite', '?'), ('host_halo_id', 'i8'),
     ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
-    ('host_x', 'f4'), ('host_y', 'f4'), ('host_z', 'f4')))
+    ('host_halo_x', 'f4'), ('host_halo_y', 'f4'), ('host_halo_z', 'f4')))
 default_dt_source_gals = np.dtype([(str(a[0]), str(a[1])) for a in source_gals_type_list])
 
 target_halos_type_list = list((('mvir', 'f4'), ('nfw_conc', 'f4'),
@@ -59,30 +59,32 @@ def fake_source_galaxy_catalog(num_source_gals=int(1e3),
 
     galaxy_catalog = np.zeros(num_source_gals, dtype=dt_source_gals)
     galaxy_catalog['gal_id'] = gal_id_array_galaxies[:num_source_gals]
-    galaxy_catalog['mass'] = halo_mass_array[:num_source_gals]
-    galaxy_catalog['conc'] = host_conc_galaxies[:num_source_gals]
+    galaxy_catalog['host_halo_mass'] = halo_mass_array[:num_source_gals]
+    galaxy_catalog['host_halo_conc'] = host_conc_galaxies[:num_source_gals]
     galaxy_catalog['satellite'] = satellite[:num_source_gals]
     galaxy_catalog['host_halo_id'] = halo_id_galaxies[:num_source_gals]
-    galaxy_catalog['host_x'] = host_x_galaxies[:num_source_gals]
-    galaxy_catalog['host_y'] = host_y_galaxies[:num_source_gals]
-    galaxy_catalog['host_z'] = host_z_galaxies[:num_source_gals]
+    galaxy_catalog['host_halo_x'] = host_x_galaxies[:num_source_gals]
+    galaxy_catalog['host_halo_y'] = host_y_galaxies[:num_source_gals]
+    galaxy_catalog['host_halo_z'] = host_z_galaxies[:num_source_gals]
     galaxy_catalog['x'] = host_x_galaxies[:num_source_gals]
     galaxy_catalog['y'] = host_y_galaxies[:num_source_gals]
     galaxy_catalog['z'] = host_z_galaxies[:num_source_gals]
-    galaxy_catalog['host_rvir'] = host_rvir_galaxies[:num_source_gals]
+    galaxy_catalog['host_halo_rvir'] = host_rvir_galaxies[:num_source_gals]
 
     satmask = galaxy_catalog['satellite'] == True
     nsats = np.count_nonzero(satmask)
     with NumpyRNGContext(seed):
-        dx = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_rvir'][satmask]
-        dy = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_rvir'][satmask]
-        dz = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_rvir'][satmask]
+        dx = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
+        dy = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
+        dz = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
 
     galaxy_catalog['x'][satmask] += dx
     galaxy_catalog['y'][satmask] += dy
     galaxy_catalog['z'][satmask] += dz
 
-    return galaxy_catalog
+    idx_ransort = np.random.choice(np.arange(num_source_gals), num_source_gals, replace=False)
+
+    return galaxy_catalog[idx_ransort]
 
 
 def mean_halo_concentration(logM):

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -8,7 +8,7 @@ from scipy.stats import poisson
 
 from ..numpy_random_context import NumpyRNGContext
 
-__all__ = ('fake_source_galaxy_catalog', )
+__all__ = ('fake_source_galaxy_catalog', 'fake_target_halo_catalog')
 
 
 source_gals_type_list = list((('gal_id', 'i8'),
@@ -19,7 +19,7 @@ source_gals_type_list = list((('gal_id', 'i8'),
 default_dt_source_gals = np.dtype([(str(a[0]), str(a[1])) for a in source_gals_type_list])
 
 target_halos_type_list = list((('mass', 'f4'), ('conc', 'f4'),
-        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'), ('rvir' ,'f4'),
+        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'), ('rvir', 'f4'),
         ('halo_id', 'i8')))
 default_dt_target_halos = np.dtype([(str(a[0]), str(a[1])) for a in target_halos_type_list])
 

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -5,36 +5,66 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from scipy.special import erf
 
-from .numpy_random_context import NumpyRNGContext
+from ..numpy_random_context import NumpyRNGContext
+
+__all__ = ('fake_source_galaxy_catalog', )
 
 
-default_dt_source_gals = np.dtype(
-        [('gal_id', 'i8'), ('mass', 'f4'), ('conc', 'f4'), ('satellite', bool),
+source_gals_type_list = list((('gal_id', 'i8'), ('mass', 'f4'), ('conc', 'f4'),
+    ('satellite', '?'), ('host_halo_id', 'i8'),
+    ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
+    ('host_x', 'f4'), ('host_y', 'f4'), ('host_z', 'f4')))
+default_dt_source_gals = np.dtype([(str(a[0]), str(a[1])) for a in source_gals_type_list])
+
+target_halos_type_list = list((('mvir', 'f4'), ('nfw_conc', 'f4'),
         ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
-        ('host_x', 'f4'), ('host_y', 'f4'), ('host_z', 'f4'),
-        ('host_halo_id', 'i8')])
-
-default_dt_target_halos = np.dtype(
-        [('mvir', 'f4'), ('nfw_conc', 'f4'),
-        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
-        ('halo_id', 'i8')])
+        ('halo_id', 'i8')))
+default_dt_target_halos = np.dtype([(str(a[0]), str(a[1])) for a in target_halos_type_list])
 
 
 def fake_source_galaxy_catalog(num_source_gals=int(1e3),
         dt_source_gals=default_dt_source_gals, seed=None, Lbox=250.):
     """
     """
+    num_source_halos = num_source_gals*5
+    halo_mass_array = mc_halo_mass(num_source_halos, seed=seed)
 
-    with NumpyRNGContext(seed):
-        x = np.random.rand(num_source_gals)
+    galaxy_catalog = np.zeros(num_source_gals, dtype=dt_source_gals)
+
+    return galaxy_catalog
 
 
-def mean_ncen(logM, logM_min=12, sigma_logM=0.2):
+def mean_ncen(logM, logM_min, sigma_logM):
     return 0.5*(1.0 + erf((logM - logM_min) / sigma_logM))
 
 
-def mean_nsat(m, M0=10.**12):
-    M1 = 20.*M0
-    return (m - M0)/M1
+def mean_nsat(m, logM_min):
+    log_M0 = logM_min-0.3
+    log_M1 = log_M0+1.5
+    M0, M1 = 10**log_M0, 10**log_M1
+    return np.maximum((m - M0)/M1, 0.0001)
 
+
+def mean_ngal(m, logM_min, sigma_logM=0.2):
+    return mean_ncen(np.log10(m), logM_min, sigma_logM) + mean_nsat(m, logM_min)
+
+
+def halo_abundance(logM, logM_min=9.):
+    return 0.5*(1.0 + erf((logM - logM_min) / 3))
+
+
+def mc_halo_mass(num_halos=int(1e3), seed=None):
+    logM_table = np.linspace(10., 15.5, 500)
+
+    unscaled_cdf_inv_table = halo_abundance(logM_table)
+    ymin = unscaled_cdf_inv_table.min()
+    ymax = unscaled_cdf_inv_table.max()
+    dy = ymax-ymin
+    cdf_inv_table = unscaled_cdf_inv_table/dy
+    cdf_inv_table -= cdf_inv_table.min()
+
+    with NumpyRNGContext(seed):
+        randoms = np.random.rand(num_halos)
+
+    return np.interp(randoms, cdf_inv_table, logM_table)
 

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -18,8 +18,8 @@ source_gals_type_list = list((('gal_id', 'i8'),
     ('host_halo_x', 'f4'), ('host_halo_y', 'f4'), ('host_halo_z', 'f4')))
 default_dt_source_gals = np.dtype([(str(a[0]), str(a[1])) for a in source_gals_type_list])
 
-target_halos_type_list = list((('mvir', 'f4'), ('nfw_conc', 'f4'),
-        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
+target_halos_type_list = list((('mass', 'f4'), ('conc', 'f4'),
+        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'), ('rvir' ,'f4'),
         ('halo_id', 'i8')))
 default_dt_target_halos = np.dtype([(str(a[0]), str(a[1])) for a in target_halos_type_list])
 
@@ -85,6 +85,26 @@ def fake_source_galaxy_catalog(num_source_gals=int(1e3),
     idx_ransort = np.random.choice(np.arange(num_source_gals), num_source_gals, replace=False)
 
     return galaxy_catalog[idx_ransort]
+
+
+def fake_target_halo_catalog(num_target_halos=int(1e5),
+        dt_target_halos=default_dt_target_halos, seed=None, Lbox=5000.):
+    """
+    Examples
+    --------
+    >>> target_halos = fake_target_halo_catalog()
+    """
+    halos = np.zeros(num_target_halos, dtype=dt_target_halos)
+
+    halos['mass'] = 10**mc_halo_mass(num_target_halos, seed=seed)
+    halos['x'] = np.random.uniform(1, Lbox-1, num_target_halos)
+    halos['y'] = np.random.uniform(1, Lbox-1, num_target_halos)
+    halos['z'] = np.random.uniform(1, Lbox-1, num_target_halos)
+    halos['conc'] = 10**np.random.normal(
+        loc=np.log10(mean_halo_concentration(np.log10(halos['mass']))), scale=0.1)
+    halos['rvir'] = np.random.rand(num_target_halos)
+    halos['halo_id'] = np.arange(len(halos)).astype('i8')
+    return halos
 
 
 def mean_halo_concentration(logM):

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -4,13 +4,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from scipy.special import erf
+from scipy.stats import poisson
 
 from ..numpy_random_context import NumpyRNGContext
 
 __all__ = ('fake_source_galaxy_catalog', )
 
 
-source_gals_type_list = list((('gal_id', 'i8'), ('mass', 'f4'), ('conc', 'f4'),
+source_gals_type_list = list((('gal_id', 'i8'),
+    ('mass', 'f4'), ('conc', 'f4'), ('host_rvir', 'f4'),
     ('satellite', '?'), ('host_halo_id', 'i8'),
     ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
     ('host_x', 'f4'), ('host_y', 'f4'), ('host_z', 'f4')))
@@ -23,15 +25,70 @@ default_dt_target_halos = np.dtype([(str(a[0]), str(a[1])) for a in target_halos
 
 
 def fake_source_galaxy_catalog(num_source_gals=int(1e3),
-        dt_source_gals=default_dt_source_gals, seed=None, Lbox=250.):
+        dt_source_gals=default_dt_source_gals, seed=None, Lbox=250.,
+        logM_min=12, sigma_logM=0.25):
     """
+    Examples
+    --------
+    >>> galaxy_catalog = fake_source_galaxy_catalog()
     """
     num_source_halos = num_source_gals*5
-    halo_mass_array = mc_halo_mass(num_source_halos, seed=seed)
+
+    m = 10**mc_halo_mass(num_source_halos, seed=seed)
+    host_x = np.random.uniform(1, Lbox-1, num_source_halos)
+    host_y = np.random.uniform(1, Lbox-1, num_source_halos)
+    host_z = np.random.uniform(1, Lbox-1, num_source_halos)
+    host_conc = 10**np.random.normal(
+        loc=np.log10(mean_halo_concentration(np.log10(m))), scale=0.1)
+    rvir = np.random.rand(num_source_halos)
+
+    mc_ncen = np.random.rand(num_source_halos) < mean_ncen(np.log10(m), logM_min, sigma_logM)
+    mc_nsat = poisson.rvs(mean_nsat(m, logM_min))
+    ngal = mc_ncen + mc_nsat
+    halo_mass_array = np.repeat(m, ngal)
+    halo_id_galaxies = np.repeat(np.arange(len(m)).astype(int), ngal)
+    gal_id_array_galaxies = np.arange(len(halo_id_galaxies)).astype(int)
+    host_x_galaxies = np.repeat(host_x, ngal)
+    host_y_galaxies = np.repeat(host_y, ngal)
+    host_z_galaxies = np.repeat(host_z, ngal)
+    host_rvir_galaxies = np.repeat(rvir, ngal)
+    host_conc_galaxies = np.repeat(host_conc, ngal)
+    unique_ids, idx = np.unique(halo_id_galaxies, return_index=True)
+    satellite = np.ones(len(halo_id_galaxies), dtype=bool)
+    satellite[idx] = False
 
     galaxy_catalog = np.zeros(num_source_gals, dtype=dt_source_gals)
+    galaxy_catalog['gal_id'] = gal_id_array_galaxies[:num_source_gals]
+    galaxy_catalog['mass'] = halo_mass_array[:num_source_gals]
+    galaxy_catalog['conc'] = host_conc_galaxies[:num_source_gals]
+    galaxy_catalog['satellite'] = satellite[:num_source_gals]
+    galaxy_catalog['host_halo_id'] = halo_id_galaxies[:num_source_gals]
+    galaxy_catalog['host_x'] = host_x_galaxies[:num_source_gals]
+    galaxy_catalog['host_y'] = host_y_galaxies[:num_source_gals]
+    galaxy_catalog['host_z'] = host_z_galaxies[:num_source_gals]
+    galaxy_catalog['x'] = host_x_galaxies[:num_source_gals]
+    galaxy_catalog['y'] = host_y_galaxies[:num_source_gals]
+    galaxy_catalog['z'] = host_z_galaxies[:num_source_gals]
+    galaxy_catalog['host_rvir'] = host_rvir_galaxies[:num_source_gals]
+
+    satmask = galaxy_catalog['satellite'] == True
+    nsats = np.count_nonzero(satmask)
+    with NumpyRNGContext(seed):
+        dx = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_rvir'][satmask]
+        dy = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_rvir'][satmask]
+        dz = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_rvir'][satmask]
+
+    galaxy_catalog['x'][satmask] += dx
+    galaxy_catalog['y'][satmask] += dy
+    galaxy_catalog['z'][satmask] += dz
 
     return galaxy_catalog
+
+
+def mean_halo_concentration(logM):
+    logM_table = [10, 15]
+    conc_table = [15, 4.1]
+    return np.interp(logM, logM_table, conc_table)
 
 
 def mean_ncen(logM, logM_min, sigma_logM):
@@ -40,7 +97,7 @@ def mean_ncen(logM, logM_min, sigma_logM):
 
 def mean_nsat(m, logM_min):
     log_M0 = logM_min-0.3
-    log_M1 = log_M0+1.5
+    log_M1 = log_M0+2
     M0, M1 = 10**log_M0, 10**log_M1
     return np.maximum((m - M0)/M1, 0.0001)
 

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -74,13 +74,13 @@ def fake_source_galaxy_catalog(num_source_gals=int(1e3),
     satmask = galaxy_catalog['satellite'] == True
     nsats = np.count_nonzero(satmask)
     with NumpyRNGContext(seed):
-        dx = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
-        dy = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
-        dz = np.random.uniform(0, 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
+        dx = np.random.uniform(-1/3., 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
+        dy = np.random.uniform(-1/3., 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
+        dz = np.random.uniform(-1/3., 1/3., nsats)*galaxy_catalog['host_halo_rvir'][satmask]
 
-    galaxy_catalog['x'][satmask] += dx
-    galaxy_catalog['y'][satmask] += dy
-    galaxy_catalog['z'][satmask] += dz
+    galaxy_catalog['x'][satmask] = dx + galaxy_catalog['host_halo_x'][satmask]
+    galaxy_catalog['y'][satmask] = dy + galaxy_catalog['host_halo_y'][satmask]
+    galaxy_catalog['z'][satmask] = dz + galaxy_catalog['host_halo_z'][satmask]
 
     idx_ransort = np.random.choice(np.arange(num_source_gals), num_source_gals, replace=False)
 

--- a/galsampler/tests/fake_catalogs.py
+++ b/galsampler/tests/fake_catalogs.py
@@ -1,0 +1,40 @@
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from scipy.special import erf
+
+from .numpy_random_context import NumpyRNGContext
+
+
+default_dt_source_gals = np.dtype(
+        [('gal_id', 'i8'), ('mass', 'f4'), ('conc', 'f4'), ('satellite', bool),
+        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
+        ('host_x', 'f4'), ('host_y', 'f4'), ('host_z', 'f4'),
+        ('host_halo_id', 'i8')])
+
+default_dt_target_halos = np.dtype(
+        [('mvir', 'f4'), ('nfw_conc', 'f4'),
+        ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
+        ('halo_id', 'i8')])
+
+
+def fake_source_galaxy_catalog(num_source_gals=int(1e3),
+        dt_source_gals=default_dt_source_gals, seed=None, Lbox=250.):
+    """
+    """
+
+    with NumpyRNGContext(seed):
+        x = np.random.rand(num_source_gals)
+
+
+def mean_ncen(logM, logM_min=12, sigma_logM=0.2):
+    return 0.5*(1.0 + erf((logM - logM_min) / sigma_logM))
+
+
+def mean_nsat(m, M0=10.**12):
+    M1 = 20.*M0
+    return (m - M0)/M1
+
+

--- a/galsampler/tests/test_fake_catalogs.py
+++ b/galsampler/tests/test_fake_catalogs.py
@@ -5,6 +5,9 @@ import numpy as np
 from .fake_catalogs import fake_source_galaxy_catalog
 
 
+__all__ = ('test1', )
+
+
 def test1():
     n = int(1e3)
     Lbox = 250.
@@ -24,8 +27,8 @@ def test1():
     assert np.all(galaxy_catalog['y'] < Lbox)
     assert np.all(galaxy_catalog['z'] < Lbox)
 
-    dx = galaxy_catalog['x'] - galaxy_catalog['host_x']
-    dy = galaxy_catalog['y'] - galaxy_catalog['host_y']
-    dz = galaxy_catalog['z'] - galaxy_catalog['host_z']
-    dr = np.sqrt(dx**2 + dy**2 + dz**2)/galaxy_catalog['host_rvir']
+    dx = galaxy_catalog['x'] - galaxy_catalog['host_halo_x']
+    dy = galaxy_catalog['y'] - galaxy_catalog['host_halo_y']
+    dz = galaxy_catalog['z'] - galaxy_catalog['host_halo_z']
+    dr = np.sqrt(dx**2 + dy**2 + dz**2)/galaxy_catalog['host_halo_rvir']
     assert np.all(dr < 1)

--- a/galsampler/tests/test_fake_catalogs.py
+++ b/galsampler/tests/test_fake_catalogs.py
@@ -7,9 +7,25 @@ from .fake_catalogs import fake_source_galaxy_catalog
 
 def test1():
     n = int(1e3)
-    galaxy_catalog = fake_source_galaxy_catalog(num_source_gals=n)
-    assert len(galaxy_catalog) == n
+    Lbox = 250.
+    galaxy_catalog = fake_source_galaxy_catalog(num_source_gals=n, Lbox=Lbox)
+    ngal_msg = "Length of galaxy_catalog = {0} != {1}"
+    ngal = len(galaxy_catalog)
+    assert ngal == n, ngal_msg.format(ngal, n)
 
     fsat_msg = "Fsat = {0:.2f} of fake catalog should be between 0.1 and 0.5"
     fsat = np.mean(galaxy_catalog['satellite'])
-    assert 0.1 < fsat < 0.5, fsat_msg.format(fsat)
+    assert 0.1 < fsat < 0.75, fsat_msg.format(fsat)
+
+    assert np.all(galaxy_catalog['x'] > 0)
+    assert np.all(galaxy_catalog['y'] > 0)
+    assert np.all(galaxy_catalog['z'] > 0)
+    assert np.all(galaxy_catalog['x'] < Lbox)
+    assert np.all(galaxy_catalog['y'] < Lbox)
+    assert np.all(galaxy_catalog['z'] < Lbox)
+
+    dx = galaxy_catalog['x'] - galaxy_catalog['host_x']
+    dy = galaxy_catalog['y'] - galaxy_catalog['host_y']
+    dz = galaxy_catalog['z'] - galaxy_catalog['host_z']
+    dr = np.sqrt(dx**2 + dy**2 + dz**2)/galaxy_catalog['host_rvir']
+    assert np.all(dr < 1)

--- a/galsampler/tests/test_fake_catalogs.py
+++ b/galsampler/tests/test_fake_catalogs.py
@@ -1,0 +1,15 @@
+"""
+"""
+import numpy as np
+
+from .fake_catalogs import fake_source_galaxy_catalog
+
+
+def test1():
+    n = int(1e3)
+    galaxy_catalog = fake_source_galaxy_catalog(num_source_gals=n)
+    assert len(galaxy_catalog) == n
+
+    fsat_msg = "Fsat = {0:.2f} of fake catalog should be between 0.1 and 0.5"
+    fsat = np.mean(galaxy_catalog['satellite'])
+    assert 0.1 < fsat < 0.5, fsat_msg.format(fsat)

--- a/galsampler/tests/test_halo_binning.py
+++ b/galsampler/tests/test_halo_binning.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 
-from ..host_halo_binning import halo_bin_indices
+from ..host_halo_binning import halo_bin_indices_dict
 
 
 def test1():
@@ -14,7 +14,7 @@ def test1():
     halo_property_bins = dict(
             a=np.linspace(0, 10, num_bins_a), b=np.linspace(10, 20, num_bins_b))
 
-    bin_indices_dict = halo_bin_indices(source_halo_arrays, halo_property_bins)
+    bin_indices_dict = halo_bin_indices_dict(source_halo_arrays, halo_property_bins)
     assert np.all(bin_indices_dict['a'] >= 0)
     assert np.all(bin_indices_dict['b'] >= 0)
     assert np.all(bin_indices_dict['a'] <= num_bins_a-1)

--- a/galsampler/tests/test_halo_binning.py
+++ b/galsampler/tests/test_halo_binning.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 
-from ..host_halo_binning import halo_bin_indices_dict
+from ..host_halo_binning import halo_bin_indices_dict, unique_cell_id_from_bin_indices
 
 
 def test1():
@@ -19,3 +19,20 @@ def test1():
     assert np.all(bin_indices_dict['b'] >= 0)
     assert np.all(bin_indices_dict['a'] <= num_bins_a-1)
     assert np.all(bin_indices_dict['b'] <= num_bins_b-1)
+
+
+def test2():
+    num_halos = 100
+    source_halo_arrays = dict(
+            a=np.linspace(0, 10, num_halos), b=np.linspace(10, 20, num_halos))
+
+    num_bins_a, num_bins_b = 5, 15
+    halo_property_bins = dict(
+            a=np.linspace(0, 10, num_bins_a), b=np.linspace(10, 20, num_bins_b))
+
+    bin_indices_dict = halo_bin_indices_dict(source_halo_arrays, halo_property_bins)
+
+    unique_cell_ids = unique_cell_id_from_bin_indices(bin_indices_dict, halo_property_bins)
+
+    assert np.shape(unique_cell_ids) == (num_halos, )
+    assert np.all(unique_cell_ids <= num_bins_b*num_bins_a-1)

--- a/galsampler/tests/test_key_correspondence.py
+++ b/galsampler/tests/test_key_correspondence.py
@@ -1,0 +1,99 @@
+"""
+"""
+import pytest
+import numpy as np
+
+from .fake_catalogs import fake_target_halo_catalog
+
+from ..populate_halos import _enforce_key_correspondence, format_target_catalog
+
+
+def test1():
+    source_galaxies = dict(x=4)
+    target_halos = dict(x=4)
+    halo_property_bins = dict(x=4)
+    source_target_key_correspondence = {}
+
+    _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+            source_target_key_correspondence)
+
+
+def test2():
+    source_galaxies = dict(x=4)
+    target_halos = dict(x=4)
+    halo_property_bins = dict(x=4, y=5)
+    source_target_key_correspondence = {}
+
+    with pytest.raises(KeyError) as err:
+        _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+                source_target_key_correspondence)
+    substr = "not in ``source_galaxies``"
+    assert substr in err.value.args[0]
+
+
+def test3():
+    source_galaxies = dict(x=4, y=5)
+    target_halos = dict(x=4)
+    halo_property_bins = dict(x=4, y=5)
+    source_target_key_correspondence = {}
+
+    with pytest.raises(KeyError) as err:
+        _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+                source_target_key_correspondence)
+    substr = "but not in ``target_halos`` nor ``source_target_key_correspondence``"
+    assert substr in err.value.args[0]
+
+
+def test4():
+    source_galaxies = dict(x=4, y=5)
+    target_halos = dict(x=4, z=9)
+    halo_property_bins = dict(x=4, y=5)
+    source_target_key_correspondence = dict(y='t')
+
+    with pytest.raises(KeyError) as err:
+        _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+                source_target_key_correspondence)
+    substr = "According to ``source_target_key_correspondence``"
+    assert substr in err.value.args[0]
+
+
+def test5():
+    source_galaxies = dict(x=4, y=5)
+    target_halos = dict(x=4, z=9)
+    halo_property_bins = dict(x=4, y=5)
+    source_target_key_correspondence = dict(y='z')
+
+    _enforce_key_correspondence(source_galaxies, target_halos, halo_property_bins,
+            source_target_key_correspondence)
+
+
+def test6():
+    target_halos = fake_target_halo_catalog()
+    num_bins_mass, num_bins_conc = 12, 11
+    mass_bins = np.logspace(10, 15, num_bins_mass)
+    conc_bins = np.logspace(1.5, 20, num_bins_conc)
+
+    halo_property_bins = dict(mass=mass_bins, conc2=conc_bins)
+
+    source_target_key_correspondence = {'conc2': 'conc3'}
+    with pytest.raises(KeyError) as err:
+        formatted_target_halos = format_target_catalog(target_halos, halo_property_bins,
+                source_target_key_correspondence=source_target_key_correspondence)
+    substr = "should be a ``conc3`` key in ``target_halos``"
+    assert substr in err.value.args[0]
+
+
+def test7():
+    target_halos = fake_target_halo_catalog()
+    num_bins_mass, num_bins_conc = 12, 11
+    mass_bins = np.logspace(10, 15, num_bins_mass)
+    conc_bins = np.logspace(1.5, 20, num_bins_conc)
+
+    halo_property_bins = dict(mass=mass_bins, conc2=conc_bins)
+
+    source_target_key_correspondence = {'conc2': 'conc'}
+    formatted_target_halos = format_target_catalog(target_halos, halo_property_bins,
+            source_target_key_correspondence=source_target_key_correspondence)
+
+
+


### PR DESCRIPTION
This PR completes most of the modules necessary to set up a multi-dimensional binning correspondence between a source and target halo catalog. 

@duncandc - the `populate_target_halos` function is currently the main user-facing function. Short term goals are just to get this hooked into `source_halo_index_selection`, with the goal of `fake_source_galaxy_catalog` being used to populate `fake_target_halo_catalog`. Unless I'm missing something, that will require very little additional code. 

Subsequent step will be to get genericIO plugged into this, which @dkorytov tells me will be easy. That will let us scale up Galacticus into Outer Rim in relatively short order (hopefully early next week). This code is written with sufficient abstraction that I think (hope) it will be quite trivial to do this sampling again whenever there is an update to Galacticus. 

Since the EAGLE snapshots [are fully public](http://icc.dur.ac.uk/Eagle/database.php) now, I think it would be *great* to scale that up using this machinery. There are ~30 snapshots of the Lbox=100Mpc/h run spanning 0 < z < 20, which should be completely sufficient for these purposes. There's *lots* of interesting science to do with that data, e.g., rescaling calculations such as @duncandc seemed interested in. Plus it would be extremely valuable to have a scaled up hydro mock for DC2. In principle, we can do the same thing for a few Millennium mocks, giving us a good handful of finely tuned methods all populated into Outer Rim. I would certainly accept volunteers for help with the data acquisition, but I'll put this on my own medium term queue for the time being. Tagging @yymao so that he is aware of this program, all of which seems well within reach of DC2. 
